### PR TITLE
Remove [f] flag from llvm-ar call

### DIFF
--- a/LLVMBitcode.cmake
+++ b/LLVMBitcode.cmake
@@ -151,7 +151,7 @@ function(build_llvm_bitcode_lib OUTPUT FLAGS INC_DIRS SRC)
 
   # Build the bitcode library
   add_custom_command(OUTPUT ${OUTPUT}
-                     COMMAND ${AR} rcsf ${OUTPUT} ${BC_FILES}
+                     COMMAND ${AR} rcs ${OUTPUT} ${BC_FILES}
                      DEPENDS ${BC_FILES})
   add_custom_target(${OUTPUT_BASE} ALL DEPENDS ${OUTPUT})
 endfunction(build_llvm_bitcode_lib)


### PR DESCRIPTION
The [f] flag was removed from llvm-ar at some point, so usages of `build_llvm_bitcode_lib` fail with `llvm-ar: unknown option f.` I haven't found exactly when it was removed, but it looks like it was some time between 3.0 and 4.0, and it's still missing in 7.0.

## Old docs

> http://releases.llvm.org/3.0/docs/CommandGuide/html/llvm-ar.html
>
> **[f]** Normally, llvm-ar stores the full path name to a file as presented to it on the command line. With this option, truncated (15 characters max) names are used. This ensures name compatibility with older versions of ar but may also thwart correct extraction of the files (duplicates may overwrite). If used with the R option, the directory recursion will be performed but the file names will all be flattened to simple file names.
